### PR TITLE
[22/02] Info box

### DIFF
--- a/OSMProject/Source/OSMProject/PlayerPawn.cpp
+++ b/OSMProject/Source/OSMProject/PlayerPawn.cpp
@@ -176,10 +176,13 @@ void APlayerPawn::CastTrace(){
 	if (DidTrace) {
 		selectedActor = RV_Hit.GetActor();
 		Hud->setCrosshairColor(FColor::Red);
+		// Hud->sendActorInfo();
+		Hud->setInfoBoxVisibility(true);
 	}
 	else{
 		selectedActor = nullptr;
 		Hud->setCrosshairColor(FColor::White);
+		Hud->setInfoBoxVisibility(false);
 	}
 }
 

--- a/OSMProject/Source/OSMProject/ViewerHUD.cpp
+++ b/OSMProject/Source/OSMProject/ViewerHUD.cpp
@@ -6,8 +6,10 @@
 #include "Public/CanvasItem.h"
 
 AViewerHUD::AViewerHUD() {
-	CrosshairColor = FColor::White;
-	CrosshairSize = 15;
+	CrosshairColor_ = FColor::White;
+	CrosshairSize_ = 15;
+	showInfoBox_ = false;
+	infoBoxLines_ = 1;
 }
 
 void AViewerHUD::DrawHUD()
@@ -17,14 +19,40 @@ void AViewerHUD::DrawHUD()
 	// Find the center of our canvas.
 	FVector2D Center(Canvas->ClipX * 0.5f, Canvas->ClipY * 0.5f);
 
-	//Crosshair
-	Draw2DLine(Center.X - CrosshairSize, Center.Y, Center.X + CrosshairSize, Center.Y, CrosshairColor);
-	Draw2DLine(Center.X, Center.Y - CrosshairSize, Center.X, Center.Y + CrosshairSize, CrosshairColor);
+	// Crosshair
+	Draw2DLine(Center.X - CrosshairSize_, Center.Y, Center.X + CrosshairSize_, Center.Y, CrosshairColor_);
+	Draw2DLine(Center.X, Center.Y - CrosshairSize_, Center.X, Center.Y + CrosshairSize_, CrosshairColor_);
+
+	// Info Box
+	if (showInfoBox_) {
+		DrawRect(
+			FLinearColor(0, 0, 0, 0.4), // Box color and opacity.
+			Center.X + 150,				// X coordinates of box's top left corner.
+			40,							// Y coordinates of box's top left corner.
+			400,						// Box's width.
+			infoBoxLines_ * 15			// Box's height.
+		);
+
+		// Info Box content
+		for(int i = 0; i < infoBoxLines_; i++){
+			DrawText(TEXT("Here it'll be info box content !"), FLinearColor::White, Center.X + 150, 40 + (i * 15));
+		}
+	}
 
 	DrawText(TEXT("ViewerHUD v1"), FLinearColor::Black, Center.X - 40, 10);
 }
 
 void AViewerHUD::setCrosshairColor(FColor color) {
-	CrosshairColor = color;
+	CrosshairColor_ = color;
+}
+
+void AViewerHUD::setInfoBoxVisibility(bool v) {
+	showInfoBox_ = v;
+}
+
+void AViewerHUD::sendActorInfo(/* Parameter, by reference, in which it'll contain actor info */) {
+	// Attribute of ViewerHUD = parameter
+
+	// infoBoxLines_ = number of infos to show
 }
 

--- a/OSMProject/Source/OSMProject/ViewerHUD.h
+++ b/OSMProject/Source/OSMProject/ViewerHUD.h
@@ -14,12 +14,16 @@ class OSMPROJECT_API AViewerHUD : public AHUD
 {
 	GENERATED_BODY()
 	
-protected:
-	FColor CrosshairColor;
-	float CrosshairSize;
+private:
+	FColor CrosshairColor_;
+	float CrosshairSize_;
+	int infoBoxLines_;
+	bool showInfoBox_;
 
 public:
 	AViewerHUD();
 	virtual void DrawHUD() override;
 	void setCrosshairColor(FColor color);
+	void setInfoBoxVisibility(bool v);
+	void sendActorInfo();
 };


### PR DESCRIPTION
- Ajout d'une boîte d'informations sur l'HUD : cette dernière s'affiche si l'utilisateur a sélectionné un acteur dans le niveau. Pour la faire disparaître, l'utilisateur doit déselectionner cet acteur, en cliquant dans le vide.

- Ajout de code préparatoire pour la future inclusion de la partie OSM.