### PR TITLE
[11-03] Osmium, modifications du code

### DIFF
--- a/OSMProject/SourceOSM/DataHandler.h
+++ b/OSMProject/SourceOSM/DataHandler.h
@@ -3,51 +3,79 @@
 #include <osmium/handler.hpp>
 #include <osmium/osm/node.hpp>
 #include <osmium/osm/way.hpp>
-//#include <osmium/osm/relation.hpp>
+#include <osmium/osm/relation.hpp>
 #include <iostream>
+#include <algorithm>
 
 class DataHandler : public osmium::handler::Handler {
 private:
-	//Hashmap for restrictive osm file reading : in this example, we are looking for names and sources in ways and nodes
+	enum Type { Way, Node, Relation };
+
+	//Hashmap for restrictive osm file reading : in this example, we are looking for names and sources in ways, nodes and relations
 	//in which there are a tag highway, residential.
 	//Element example : ("highway", ("residential", {"name", "source"}))
 	std::map<std::string, std::map<std::string, std::vector<std::string>>> dataToExtract_;
 
-	//Hashmap to store information, by node/way id. For each id, we have a list of pairs :
+	//Hashmaps to store information, by node/way/relation id. For each id, we have a list of pairs :
 	//left member : tag name, right member : its value.
 	//Element example : ("1254125", {("name", "duschmoll"), ("source", "toto industries")})
-	std::map<std::string, std::vector<std::pair<std::string, std::string>>> dataStorage_;
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> dataStorageRelations_;
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> dataStorageNodes_;
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> dataStorageWays_;
 
-	void insertValue(std::string id, std::string tagname, std::string tagvalue) {
-		auto it = dataStorage_.find(id);
-		// Way/Node with this id is not in the hashmap yet.
-		if (it == dataStorage_.end()) {
+	void insertValue(std::string id, std::string tagname, std::string tagvalue, std::map<std::string, std::vector<std::pair<std::string, std::string>>>& dataStorage) {
+		auto it = dataStorage.find(id);
+		// Way/Node/Relation with this id is not in the hashmap yet.
+		if (it == dataStorage.end()) {
 			std::vector<std::pair<std::string, std::string>> v{ std::pair<std::string, std::string>(tagname, tagvalue) };
-			dataStorage_.insert(std::pair < std::string, std::vector<std::pair<std::string, std::string>>>(id, v));
+			dataStorage.insert(std::pair < std::string, std::vector<std::pair<std::string, std::string>>>(id, v));
 		}
 		else {
-			it->second.push_back(std::pair<std::string, std::string>(tagname, tagvalue));
+			// Check if this pair is already in the hashmap.
+			auto itbis = std::find_if(it->second.begin(), it->second.end(), [&tagname, &tagvalue](const std::pair<std::string, std::string> element) { return (element.first == tagname) && (element.second == tagvalue); });
+			if (itbis == it->second.end()) {
+				it->second.push_back(std::pair<std::string, std::string>(tagname, tagvalue));
+			}
 		}
 	}
 
-	void storeData(const osmium::OSMObject& object) {
+	bool storeOSMObject(const osmium::OSMObject& object, std::map<std::string, std::vector<std::pair<std::string, std::string>>>& dataStorage) {
+		bool match = false;
 		const osmium::TagList& tags = object.tags();
 		// For each category we want to search (example : highway).
 		for (auto itcat = dataToExtract_.begin(); itcat != dataToExtract_.end(); itcat++) {
-			// For each subcategory we want to search (example : residential).
+		// For each subcategory we want to search (example : residential).
 			for (auto itsubcat = itcat->second.begin(); itsubcat != itcat->second.end(); itsubcat++) {
-				// If the node or the way has a tag which match the current category and subcategory (ex : highway, residential)
+				// If the node/way/relation has a tag which match the current category and subcategory (ex : highway, residential)
 				if (tags.has_tag(itcat->first.c_str(), itsubcat->first.c_str())) {
+					if (!match) match = true;
 					for (std::string tagname : itsubcat->second) {
 						// Store value if it is set.
 						const char* value = tags[tagname.c_str()];
 						if (value) {
-							insertValue(std::to_string(object.id()), tagname, value);
+							insertValue(std::to_string(object.id()), tagname, value, dataStorage);
 						}
 					}
 				}
 			}
 		}
+		return match;
+	}
+
+	bool storeData(const osmium::OSMObject& object, Type type) {
+		bool match;
+		switch (type) {
+			case Way:
+				match = storeOSMObject(object, dataStorageWays_);
+				break;
+			case Node:
+				match = storeOSMObject(object, dataStorageNodes_);
+				break;
+			case Relation:
+				match = storeOSMObject(object, dataStorageRelations_);
+				break;
+		}
+		return match;
 	}
 
 public:
@@ -55,37 +83,49 @@ public:
 		dataToExtract_ = dataToGet;
 	}
 
-	std::map<std::string, std::vector<std::pair<std::string, std::string>>> getDataStorage() {
-		return dataStorage_;
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> getDataStorageRelations() {
+		return dataStorageRelations_;
+	}
+
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> getDataStorageNodes() {
+		return dataStorageNodes_;
+	}
+
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> getDataStorageWays() {
+		return dataStorageWays_;
 	}
 
 	void way(const osmium::Way& way) {
-		/*std::cout << "way " << way.id() << std::endl;
-		for (const osmium::NodeRef& nr : way.nodes()) {
-			std::cout << "waynoderef " << nr.ref() << std::endl;
+		bool match = storeData(way, Way);
+		if (match) {
+			//For each node reference, add its lontitude and latitude values to the nodes hashmap.
+			for (const osmium::NodeRef& nr : way.nodes()) {
+				insertValue(std::to_string(way.id()), "noderef", std::to_string(nr.ref()), dataStorageWays_);
+				insertValue(std::to_string(nr.ref()), "lon", std::to_string(nr.lon()), dataStorageNodes_);
+				insertValue(std::to_string(nr.ref()), "lat", std::to_string(nr.lat()), dataStorageNodes_);
+			}
 		}
-		for (const osmium::Tag& t : way.tags()) {
-			std::cout << "waytag " << t.key() << "=" << t.value() << std::endl;
-		}*/
-		storeData(way);
 	}
 
 	void node(const osmium::Node& node) {
-		/*std::cout << "node " << node.id() << " : " << node.location() << std::endl;
-		// Not used yet ? : node.location().x(), node.location().y(), node.location().lon(), node.location().lat().
-		for (const osmium::Tag& t : node.tags()) {
-			std::cout << "nodetag " << t.key() << "=" << t.value() << std::endl;
-		}*/
-		storeData(node);
+		bool match = storeData(node, Node);
+		if (match) {
+			// Retrieve lontitude and latitude for this node.
+			insertValue(std::to_string(node.id()), "lon", std::to_string(node.location().lon()), dataStorageNodes_);
+			insertValue(std::to_string(node.id()), "lat", std::to_string(node.location().lat()), dataStorageNodes_);
+		}
 	}
 
-	/*void relation(const osmium::Relation& relation) {
-		std::cout << "relation " << relation.id() << std::endl;
-		for (const osmium::RelationMember& rm : relation.members()) {
-			std::cout << "relationmember " << rm.type() << ": " << rm.ref() << "=" << rm.role() << std::endl;
+	void relation(const osmium::Relation& relation) {
+		bool match = storeData(relation, Relation);
+		if (match) {
+			// Keep type of relation (boundary, ...) and for each member, its type (way, node, relation), id and role (admin_center, stop, "", ...)
+			insertValue(std::to_string(relation.id()), "type", relation.tags()["type"], dataStorageRelations_);
+			for (const osmium::RelationMember& rm : relation.members()) {
+				std::string s(1, osmium::item_type_to_char(rm.type()));
+				insertValue(std::to_string(relation.id()), s, std::to_string(rm.ref()), dataStorageRelations_);
+				insertValue(std::to_string(relation.id()), std::to_string(rm.ref()), rm.role(), dataStorageRelations_);
+			}
 		}
-		for (const osmium::Tag& t : relation.tags()) {
-			std::cout << "relationtag " << t.key() << "=" << t.value() << std::endl;
-		}
-	}*/
+	}
 };

--- a/OSMProject/SourceOSM/OsmWIthOsmium.cpp
+++ b/OSMProject/SourceOSM/OsmWIthOsmium.cpp
@@ -2,6 +2,8 @@
 #include "DataHandler.h"
 
 #include <osmium/visitor.hpp>
+#include <osmium/index/map/sparse_mem_array.hpp>
+#include <osmium/handler/node_locations_for_ways.hpp>
 
 void OsmWithOsmium::openFile(std::string filePath) {
 	inputFile_ = osmium::io::File(filePath);
@@ -30,19 +32,28 @@ void OsmWithOsmium::addDataToExtract(std::string category, std::string subcatego
 
 void OsmWithOsmium::readInputFile() {
 	//Optional unused argument to implement ? (Restrictive read)
-	//osmium::osm_entity_bits::relation 	Read relations
 	//osmium::osm_entity_bits::changeset 	Read changesets
 	//osmium::osm_entity_bits::all 	Read all of the above
-	osmium::io::Reader reader(inputFile_, osmium::osm_entity_bits::node | osmium::osm_entity_bits::way);
-	DataHandler handler;
+	osmium::io::Reader reader(inputFile_, osmium::osm_entity_bits::node | osmium::osm_entity_bits::way | osmium::osm_entity_bits::relation);
 
 	//We need to call this function before apply, in order to have a restrictive search while reading.
+	DataHandler handler;
 	handler.setDataToExtract(dataToExtract_);
 
-	osmium::apply(reader, handler);
+	//Handler in order to have node locations for ways references (all of them are nodes)
+	namespace map = osmium::index::map;
+	using index_type = map::SparseMemArray<osmium::unsigned_object_id_type, osmium::Location>;
+	using location_handler_type = osmium::handler::NodeLocationsForWays<index_type>;
+
+	index_type index;
+	location_handler_type location_handler{ index };
+
+	osmium::apply(reader, location_handler, handler);
 
 	//Retrieve all the data we got from reading the input file.
-	dataStorage_ = handler.getDataStorage();
+	dataStorageNodes_ = handler.getDataStorageNodes();
+	dataStorageWays_ = handler.getDataStorageWays();
+	dataStorageRelations_ = handler.getDataStorageRelations();
 
 	// We do not have to close the Reader explicitly, but because the
 	// destructor can't throw, we will not see any errors otherwise.
@@ -55,13 +66,34 @@ osmium::io::Header OsmWithOsmium::getInputFileHeader() {
 	return reader.header();
 }
 
-// Shows data storage hashmap content in console.
+// Show data storage hashmaps content in console.
 // For debug purposes only.
-void OsmWithOsmium::printDataStorage() {
-	for (auto it = dataStorage_.begin(); it != dataStorage_.end(); it++) {
-		std::cout << "Object " << it->first << " :" << std::endl;
-		for (auto pair : it->second) {
-			std::cout << "\t" << pair.first << " : " << pair.second << std::endl;
+void OsmWithOsmium::printDataStorage(bool showNodes, bool showWays, bool showRelations) {
+	if (showNodes) {
+		std::cout << "----------- NODES -----------" << std::endl;
+		for (auto it = dataStorageNodes_.begin(); it != dataStorageNodes_.end(); it++) {
+			std::cout << "Node " << it->first << " :" << std::endl;
+			for (auto pair : it->second) {
+				std::cout << "\t" << pair.first << " : " << pair.second << std::endl;
+			}
+		}
+	}
+	if (showWays) {
+		std::cout << "----------- WAYS -----------" << std::endl;
+		for (auto it = dataStorageWays_.begin(); it != dataStorageWays_.end(); it++) {
+			std::cout << "Way " << it->first << " :" << std::endl;
+			for (auto pair : it->second) {
+				std::cout << "\t" << pair.first << " : " << pair.second << std::endl;
+			}
+		}
+	}
+	if (showRelations) {
+		std::cout << "----------- RELATIONS -----------" << std::endl;
+		for (auto it = dataStorageRelations_.begin(); it != dataStorageRelations_.end(); it++) {
+			std::cout << "Relation " << it->first << " :" << std::endl;
+			for (auto pair : it->second) {
+				std::cout << "\t" << pair.first << " : " << pair.second << std::endl;
+			}
 		}
 	}
 }

--- a/OSMProject/SourceOSM/OsmWithOsmium.h
+++ b/OSMProject/SourceOSM/OsmWithOsmium.h
@@ -7,12 +7,14 @@ class OsmWithOsmium {
 private:
 	osmium::io::File inputFile_;
 	std::map<std::string, std::map<std::string, std::vector<std::string>>> dataToExtract_;
-	std::map<std::string, std::vector<std::pair<std::string, std::string>>> dataStorage_;
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> dataStorageRelations_;
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> dataStorageNodes_;
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> dataStorageWays_;
 
 public:
 	void openFile(std::string filePath);
 	void readInputFile();
 	void addDataToExtract(std::string category, std::string subcategory, std::vector<std::string> tags);
 	osmium::io::Header getInputFileHeader();
-	void printDataStorage();
+	void printDataStorage(bool showNodes, bool showWays, bool showRelations);
 };


### PR DESCRIPTION
- Le handler de lecture reconnait désormais les relations.

- Les informations à stocker sont désormais dispatchés dans trois dictionnaires au lieu d'un auparavant (par exemple, la propriété latitude d'un node est désormais stocké dans le dictionnaire des nodes : dataStorageNodes_).

- Ajout des getters pour récupérer, une fois la lecture du fichier OSM terminée, les dictionnaires d'informations stockées.

- Modification de la fonction insertValue, qui prend désormais un dictionnaire en paramètre. La fonction vérifie aussi également si une paire est déjà dans le dictionnaire afin d'éviter les doublons.

- Création de la fonction storeOSMObject, qui retourne vrai si un node/way/relation a un tag correspondant à la catégorie/sous-catégorie recherchée (par exemple, boundary / administrative). Faux sinon. Cette fonction ajoute également les attributs demandés par la lecture restrictive (dictionnaire dataToExtract_) si le tag existe avec la valeur associée (name, source, ...)

- La fonction storeData retourne désormais un bool (retour de la fonction storeOSMObject) et prend désormais en paramètre une valeur énumérative, afin de donner les bons paramètres à la fonction storeOSMObject selon si on est en train de lire un node, un way ou une relation.

- Mise à jour des fonctions way et node, permettant de récupérer la lontitude et latitude des nodes et références des nodes d'un way validés par la recherche.

- Modification de la fonction readInputFile, qui utilise un handler supplémentaire pour récupérer la lontitude et latitude d'un node référencé dans un way.

- Modification de la fonction printDataStorage, qui permet désormais d'afficher à la console les trois dictionnaires d'informations récoltées. Il est possible d'afficher de 0 à 3 dictionnaires via les booléens passés en paramètre. (Vrai : Afficher le dico correspondant, Faux : ne pas afficher le dico correspondant).

NOTE : LA GESTION DES RELATIONS EST INCOMPLÈTE, PUISQUE SEULES LES REFERENCES DES NODES/WAYS/RELATIONS SONT STOCKÉES, AVEC LEURS RÔLES. CELA SERA RÉGLÉ LORS DE MA PROCHAINE SESSION.