### PR TITLE
[12-03] Osmium, final

### DIFF
--- a/OSMProject/SourceOSM/DataHandler.h
+++ b/OSMProject/SourceOSM/DataHandler.h
@@ -9,35 +9,18 @@
 
 class DataHandler : public osmium::handler::Handler {
 private:
-	enum Type { Way, Node, Relation };
+	enum Type { Way, Node };
 
-	//Hashmap for restrictive osm file reading : in this example, we are looking for names and sources in ways, nodes and relations
+	//Hashmap for restrictive osm file reading : in this example, we are looking for names and sources in ways and nodes
 	//in which there are a tag highway, residential.
 	//Element example : ("highway", ("residential", {"name", "source"}))
 	std::map<std::string, std::map<std::string, std::vector<std::string>>> dataToExtract_;
 
-	//Hashmaps to store information, by node/way/relation id. For each id, we have a list of pairs :
+	//Hashmaps to store information, by node/way id. For each id, we have a list of pairs :
 	//left member : tag name, right member : its value.
 	//Element example : ("1254125", {("name", "duschmoll"), ("source", "toto industries")})
-	std::map<std::string, std::vector<std::pair<std::string, std::string>>> dataStorageRelations_;
 	std::map<std::string, std::vector<std::pair<std::string, std::string>>> dataStorageNodes_;
 	std::map<std::string, std::vector<std::pair<std::string, std::string>>> dataStorageWays_;
-
-	void insertValue(std::string id, std::string tagname, std::string tagvalue, std::map<std::string, std::vector<std::pair<std::string, std::string>>>& dataStorage) {
-		auto it = dataStorage.find(id);
-		// Way/Node/Relation with this id is not in the hashmap yet.
-		if (it == dataStorage.end()) {
-			std::vector<std::pair<std::string, std::string>> v{ std::pair<std::string, std::string>(tagname, tagvalue) };
-			dataStorage.insert(std::pair < std::string, std::vector<std::pair<std::string, std::string>>>(id, v));
-		}
-		else {
-			// Check if this pair is already in the hashmap.
-			auto itbis = std::find_if(it->second.begin(), it->second.end(), [&tagname, &tagvalue](const std::pair<std::string, std::string> element) { return (element.first == tagname) && (element.second == tagvalue); });
-			if (itbis == it->second.end()) {
-				it->second.push_back(std::pair<std::string, std::string>(tagname, tagvalue));
-			}
-		}
-	}
 
 	bool storeOSMObject(const osmium::OSMObject& object, std::map<std::string, std::vector<std::pair<std::string, std::string>>>& dataStorage) {
 		bool match = false;
@@ -46,14 +29,15 @@ private:
 		for (auto itcat = dataToExtract_.begin(); itcat != dataToExtract_.end(); itcat++) {
 		// For each subcategory we want to search (example : residential).
 			for (auto itsubcat = itcat->second.begin(); itsubcat != itcat->second.end(); itsubcat++) {
-				// If the node/way/relation has a tag which match the current category and subcategory (ex : highway, residential)
+				// If the node/way has a tag which match the current category and subcategory (ex : highway, residential)
 				if (tags.has_tag(itcat->first.c_str(), itsubcat->first.c_str())) {
 					if (!match) match = true;
+					OsmWithOsmium::insertValue(std::to_string(object.id()), itcat->first.c_str(), itsubcat->first.c_str(), dataStorage);
 					for (std::string tagname : itsubcat->second) {
 						// Store value if it is set.
 						const char* value = tags[tagname.c_str()];
 						if (value) {
-							insertValue(std::to_string(object.id()), tagname, value, dataStorage);
+							OsmWithOsmium::insertValue(std::to_string(object.id()), tagname, value, dataStorage);
 						}
 					}
 				}
@@ -71,9 +55,6 @@ private:
 			case Node:
 				match = storeOSMObject(object, dataStorageNodes_);
 				break;
-			case Relation:
-				match = storeOSMObject(object, dataStorageRelations_);
-				break;
 		}
 		return match;
 	}
@@ -81,10 +62,6 @@ private:
 public:
 	void setDataToExtract(std::map<std::string, std::map<std::string, std::vector<std::string>>> dataToGet) {
 		dataToExtract_ = dataToGet;
-	}
-
-	std::map<std::string, std::vector<std::pair<std::string, std::string>>> getDataStorageRelations() {
-		return dataStorageRelations_;
 	}
 
 	std::map<std::string, std::vector<std::pair<std::string, std::string>>> getDataStorageNodes() {
@@ -95,14 +72,22 @@ public:
 		return dataStorageWays_;
 	}
 
+	void setDataStorageNodes(std::map<std::string, std::vector<std::pair<std::string, std::string>>> dsn) {
+		dataStorageNodes_ = dsn;
+	}
+
+	void setDataStorageWays(std::map<std::string, std::vector<std::pair<std::string, std::string>>> dsw) {
+		dataStorageWays_ = dsw;
+	}
+
 	void way(const osmium::Way& way) {
 		bool match = storeData(way, Way);
 		if (match) {
 			//For each node reference, add its lontitude and latitude values to the nodes hashmap.
 			for (const osmium::NodeRef& nr : way.nodes()) {
-				insertValue(std::to_string(way.id()), "noderef", std::to_string(nr.ref()), dataStorageWays_);
-				insertValue(std::to_string(nr.ref()), "lon", std::to_string(nr.lon()), dataStorageNodes_);
-				insertValue(std::to_string(nr.ref()), "lat", std::to_string(nr.lat()), dataStorageNodes_);
+				OsmWithOsmium::insertValue(std::to_string(way.id()), "noderef", std::to_string(nr.ref()), dataStorageWays_);
+				OsmWithOsmium::insertValue(std::to_string(nr.ref()), "lon", std::to_string(nr.lon()), dataStorageNodes_);
+				OsmWithOsmium::insertValue(std::to_string(nr.ref()), "lat", std::to_string(nr.lat()), dataStorageNodes_);
 			}
 		}
 	}
@@ -111,21 +96,8 @@ public:
 		bool match = storeData(node, Node);
 		if (match) {
 			// Retrieve lontitude and latitude for this node.
-			insertValue(std::to_string(node.id()), "lon", std::to_string(node.location().lon()), dataStorageNodes_);
-			insertValue(std::to_string(node.id()), "lat", std::to_string(node.location().lat()), dataStorageNodes_);
-		}
-	}
-
-	void relation(const osmium::Relation& relation) {
-		bool match = storeData(relation, Relation);
-		if (match) {
-			// Keep type of relation (boundary, ...) and for each member, its type (way, node, relation), id and role (admin_center, stop, "", ...)
-			insertValue(std::to_string(relation.id()), "type", relation.tags()["type"], dataStorageRelations_);
-			for (const osmium::RelationMember& rm : relation.members()) {
-				std::string s(1, osmium::item_type_to_char(rm.type()));
-				insertValue(std::to_string(relation.id()), s, std::to_string(rm.ref()), dataStorageRelations_);
-				insertValue(std::to_string(relation.id()), std::to_string(rm.ref()), rm.role(), dataStorageRelations_);
-			}
+			OsmWithOsmium::insertValue(std::to_string(node.id()), "lon", std::to_string(node.location().lon()), dataStorageNodes_);
+			OsmWithOsmium::insertValue(std::to_string(node.id()), "lat", std::to_string(node.location().lat()), dataStorageNodes_);
 		}
 	}
 };

--- a/OSMProject/SourceOSM/OsmWIthOsmium.cpp
+++ b/OSMProject/SourceOSM/OsmWIthOsmium.cpp
@@ -1,9 +1,11 @@
 #include "OsmWithOsmium.h"
 #include "DataHandler.h"
+#include "RelManager.h"
 
 #include <osmium/visitor.hpp>
 #include <osmium/index/map/sparse_mem_array.hpp>
 #include <osmium/handler/node_locations_for_ways.hpp>
+#include <osmium/relations/relations_manager.hpp>
 
 void OsmWithOsmium::openFile(std::string filePath) {
 	inputFile_ = osmium::io::File(filePath);
@@ -30,11 +32,31 @@ void OsmWithOsmium::addDataToExtract(std::string category, std::string subcatego
 	}
 }
 
+void OsmWithOsmium::insertValue(std::string id, std::string tagname, std::string tagvalue, std::map<std::string, std::vector<std::pair<std::string, std::string>>>& dataStorage) {
+	auto it = dataStorage.find(id);
+	// Way/Node/Relation with this id is not in the hashmap yet.
+	if (it == dataStorage.end()) {
+		std::vector<std::pair<std::string, std::string>> v{ std::pair<std::string, std::string>(tagname, tagvalue) };
+		dataStorage.insert(std::pair < std::string, std::vector<std::pair<std::string, std::string>>>(id, v));
+	}
+	else {
+		// Check if this pair is already in the hashmap.
+		auto itbis = std::find_if(it->second.begin(), it->second.end(), [&tagname, &tagvalue](const std::pair<std::string, std::string> element) { return (element.first == tagname) && (element.second == tagvalue); });
+		if (itbis == it->second.end()) {
+			it->second.push_back(std::pair<std::string, std::string>(tagname, tagvalue));
+		}
+	}
+}
+
 void OsmWithOsmium::readInputFile() {
-	//Optional unused argument to implement ? (Restrictive read)
-	//osmium::osm_entity_bits::changeset 	Read changesets
-	//osmium::osm_entity_bits::all 	Read all of the above
-	osmium::io::Reader reader(inputFile_, osmium::osm_entity_bits::node | osmium::osm_entity_bits::way | osmium::osm_entity_bits::relation);
+	//Relation manager, in order to have data for relations references.
+	RelManager manager;
+	manager.setDataToExtract(dataToExtract_);
+
+	osmium::relations::read_relations(inputFile_, manager);
+
+	osmium::io::Reader reader(inputFile_, osmium::osm_entity_bits::node | osmium::osm_entity_bits::way);
+	osmium::io::Reader readerManager(inputFile_, osmium::osm_entity_bits::all);
 
 	//We need to call this function before apply, in order to have a restrictive search while reading.
 	DataHandler handler;
@@ -48,16 +70,32 @@ void OsmWithOsmium::readInputFile() {
 	index_type index;
 	location_handler_type location_handler{ index };
 
+	//First pass : relations analysis and references extraction.
+	osmium::apply(readerManager, location_handler, manager.handler());
+	manager.for_each_incomplete_relation([&](const osmium::relations::RelationHandle& handle) {
+		// Access relation from handle
+		const osmium::Relation& relation = *handle;
+		std::cout << "Relation id " << relation.id() << " matches but is incomplete (some members are beyond the extract).\n";
+	});
+	dataStorageNodes_ = manager.getDataStorageNodes();
+	dataStorageWays_ = manager.getDataStorageWays();
+	dataStorageRelations_ = manager.getDataStorageRelations();
+
+	//Don't forget to retrieve modified dataStorages by the first pass before the second pass.
+	handler.setDataStorageNodes(dataStorageNodes_);
+	handler.setDataStorageWays(dataStorageWays_);
+
+	//Second pass : ways/nodes analysis and references extraction.
 	osmium::apply(reader, location_handler, handler);
 
 	//Retrieve all the data we got from reading the input file.
 	dataStorageNodes_ = handler.getDataStorageNodes();
 	dataStorageWays_ = handler.getDataStorageWays();
-	dataStorageRelations_ = handler.getDataStorageRelations();
 
 	// We do not have to close the Reader explicitly, but because the
 	// destructor can't throw, we will not see any errors otherwise.
 	reader.close();
+	readerManager.close();
 }
 
 osmium::io::Header OsmWithOsmium::getInputFileHeader() {

--- a/OSMProject/SourceOSM/OsmWithOsmium.h
+++ b/OSMProject/SourceOSM/OsmWithOsmium.h
@@ -17,4 +17,5 @@ public:
 	void addDataToExtract(std::string category, std::string subcategory, std::vector<std::string> tags);
 	osmium::io::Header getInputFileHeader();
 	void printDataStorage(bool showNodes, bool showWays, bool showRelations);
+	static void insertValue(std::string id, std::string tagname, std::string tagvalue, std::map<std::string, std::vector<std::pair<std::string, std::string>>>& dataStorage);
 };

--- a/OSMProject/SourceOSM/RelManager.h
+++ b/OSMProject/SourceOSM/RelManager.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "OsmWithOsmium.h"
+
+#include <string>
+#include <vector>
+#include <map>
+#include <iostream>
+#include <osmium/osm/node.hpp>
+#include <osmium/osm/way.hpp>
+#include <osmium/osm/relation.hpp>
+#include <osmium/relations/relations_manager.hpp>
+
+//Manager to get all the data a relation references to.
+//The first template parameter of the RelationsManager is your class, the next three template parameters 
+//tell the RelationsManager whether you are interested in member nodes, ways, and/or relations, respectively.
+class RelManager : public osmium::relations::RelationsManager<RelManager, true, true, false> {
+private:
+	std::map<std::string, std::map<std::string, std::vector<std::string>>> dataToExtract_;
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> dataStorageRelations_;
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> dataStorageNodes_;
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> dataStorageWays_;
+
+public:
+	void setDataToExtract(std::map<std::string, std::map<std::string, std::vector<std::string>>> dataToGet) {
+		dataToExtract_ = dataToGet;
+	}
+
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> getDataStorageRelations() {
+		return dataStorageRelations_;
+	}
+
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> getDataStorageNodes() {
+		return dataStorageNodes_;
+	}
+
+	std::map<std::string, std::vector<std::pair<std::string, std::string>>> getDataStorageWays() {
+		return dataStorageWays_;
+	}
+
+	//This function is called for every relation encountered in the OSM file.
+	//If a relation meet the requirements (category/subcategory we are looking for), this relation
+	//is "remembered" by the manager, for further processing.
+	bool new_relation(const osmium::Relation& relation) noexcept {
+		for (auto itcat = dataToExtract_.begin(); itcat != dataToExtract_.end(); itcat++) {
+			// For each subcategory we want to search (example : residential).
+			for (auto itsubcat = itcat->second.begin(); itsubcat != itcat->second.end(); itsubcat++) {
+				// If the relation has a tag which match the current category and subcategory (ex : highway, residential)
+				if (relation.tags().has_tag(itcat->first.c_str(), itsubcat->first.c_str())) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	//This function is called for every member of every relation that has been "remembered"
+	//by the function new_relation.
+	//We express an interest for all of these members, so simply return true.
+	bool new_member(const osmium::Relation& /*relation*/, const osmium::RelationMember& /*member*/, std::size_t /*n*/) noexcept {
+		return true;
+	}
+
+	//This function is called for each relation we have expressed an interest in,
+	//once all the members have been found in the input file.
+	void complete_relation(const osmium::Relation& relation) {
+		std::cout << "Relation id " << relation.id() << " is complete.\n";
+		//Retrie type, subtype (if it exists) of this relation.
+		OsmWithOsmium::insertValue(std::to_string(relation.id()), "type", relation.tags()["type"], dataStorageRelations_);
+		const char* value = relation.tags()[relation.tags()["type"]];
+		if(value) OsmWithOsmium::insertValue(std::to_string(relation.id()), relation.tags()["type"], value, dataStorageRelations_);
+		//Iterate over all members
+		for (const auto& member : relation.members()) {
+			// member.ref() will be 0 for all members we are not interested
+			// in. The objects for those members are not available.
+			if (member.ref() != 0) {
+				//Retrieve item type (way, node), reference and role of current member of this relation.
+				std::string membertype(1, osmium::item_type_to_char(member.type()));
+				OsmWithOsmium::insertValue(std::to_string(relation.id()), membertype, std::to_string(member.ref()), dataStorageRelations_);
+				OsmWithOsmium::insertValue(std::to_string(relation.id()), std::to_string(member.ref()), member.role(), dataStorageRelations_);
+				if (membertype == "w") { //member is a way
+					const osmium::Way* way = this->get_member_way(member.ref());
+					for (const osmium::NodeRef& nr : way->nodes()) {
+						OsmWithOsmium::insertValue(std::to_string(way->id()), "noderef", std::to_string(nr.ref()), dataStorageWays_);
+						OsmWithOsmium::insertValue(std::to_string(nr.ref()), "lon", std::to_string(nr.lon()), dataStorageNodes_);
+						OsmWithOsmium::insertValue(std::to_string(nr.ref()), "lat", std::to_string(nr.lat()), dataStorageNodes_);
+					}
+				}
+				else {
+					if (membertype == "n") { //member is a node
+						const osmium::Node* node = this->get_member_node(member.ref());
+						OsmWithOsmium::insertValue(std::to_string(node->id()), "lon", std::to_string(node->location().lon()), dataStorageNodes_);
+						OsmWithOsmium::insertValue(std::to_string(node->id()), "lat", std::to_string(node->location().lat()), dataStorageNodes_);
+					}
+				}
+			}
+		}
+	}
+};
+

--- a/OSMProject/SourceOSM/dataTest.osm
+++ b/OSMProject/SourceOSM/dataTest.osm
@@ -4,23 +4,34 @@
     <node id="701001" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lon="7.11" lat="1.04"/>
     <node id="701002" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lon="7.14" lat="1.04"/>
     <node id="701003" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lon="7.14" lat="1.01"/>
+	<node id="701004" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lon="7.14" lat="1.08"/>
+	<node id="701005" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lon="7.14" lat="1.15"/>
     <way id="701800" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
         <nd ref="701000"/>
         <nd ref="701001"/>
         <nd ref="701002"/>
-        <tag k="test:section" v="mp-geom"/>
+        <tag k="test:section" v="mp-geo"/>
         <tag k="test:id" v="701"/>
     </way>
     <way id="701801" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
         <nd ref="701002"/>
         <nd ref="701003"/>
         <nd ref="701000"/>
-        <tag k="test:section" v="mp-geom"/>
+        <tag k="test:section" v="mp-geo"/>
         <tag k="test:id" v="701"/>
     </way>
+	<relation id="701899" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
+		<member type="node" ref="701005" role ="vladiskova"/>
+        <tag k="type" v="multipolygon"/>
+        <tag k="test:section" v="mp-geom"/>
+        <tag k="test:id" v="701"/>
+        <tag k="landuse" v="forest"/>
+    </relation>
     <relation id="701900" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
         <member type="way" ref="701800" role="outer"/>
         <member type="way" ref="701801" role="outer"/>
+		<member type="node" ref="701004" role =""/>
+		<member type="relation" ref="701899" role ="test:role"/>
         <tag k="type" v="multipolygon"/>
         <tag k="test:section" v="mp-geom"/>
         <tag k="test:id" v="701"/>


### PR DESCRIPTION
- L'handler de lecture ne lit plus les relations d'un fichier OSM.

- Déplacement de la fonction insertValues, de la classe DataHandler vers la classe OsmWithOsmium. Cette fonction est désormais statique.

- Mise en place de setters pour les dictionnaires de stockage de données à conserver, dans le handler de lecture.

- Création d'un relation manager (classe RelManager), pour l'analyse des relations d'un fichier osm, et l'extraction des données relatives aux références des relations (way, node) : readInputFile se fait donc désormais en deux passes : une première pour la lecture et analyse des relations, puis une seconde lecture du fichier pour la lecture et analyse des ways/nodes.

- Mise à jour du fichier osm exemple, pour tester les fonctions du relation manager.

Non pris en compte par osmium : relations incomplètes (exemple erroné), référence à une relation dans une relation.