### PR TITLE
[21-03] Début menu en jeu

### DIFF
--- a/OSMProject/Source/OSMProject/OSMElementActor.cpp
+++ b/OSMProject/Source/OSMProject/OSMElementActor.cpp
@@ -1,0 +1,39 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "OSMElementActor.h"
+#include "Runtime/Engine/Classes/Components/StaticMeshComponent.h"
+#include "Runtime/CoreUObject/Public/UObject/ConstructorHelpers.h"
+#include "Engine/GameEngine.h"
+
+// Sets default values
+AOSMElementActor::AOSMElementActor(const FObjectInitializer& ObjectInitializer) 
+	: Super(ObjectInitializer)
+{
+ 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	PrimaryActorTick.bCanEverTick = true;
+	UStaticMeshComponent* Mesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("VisualRepresentation"));
+	RootComponent = Mesh;
+	static ConstructorHelpers::FObjectFinder<UStaticMesh> StaticMesh(TEXT("/Game/Sphere"));
+	if (StaticMesh.Succeeded())
+	{
+		Mesh->SetStaticMesh(StaticMesh.Object);
+		Mesh->SetWorldScale3D(FVector(0.5f, 0.5f, 0.5f));
+	}
+	else {
+		GEngine->AddOnScreenDebugMessage(-1, 10.0f, FColor::Red, TEXT("No asset loaded."));
+	}
+	Mesh->GetCollisionEnabled();
+}
+
+// Called when the game starts or when spawned
+void AOSMElementActor::BeginPlay()
+{
+	Super::BeginPlay();
+}
+
+// Called every frame
+void AOSMElementActor::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+}
+

--- a/OSMProject/Source/OSMProject/OSMElementActor.h
+++ b/OSMProject/Source/OSMProject/OSMElementActor.h
@@ -1,0 +1,29 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "Engine/Classes/Components/SphereComponent.h"
+#include "OSMElementActor.generated.h"
+
+UCLASS()
+class OSMPROJECT_API AOSMElementActor : public AActor
+{
+	GENERATED_BODY()
+
+private:
+	USphereComponent* CollisionComp; // Sphere collision component, needs to be more general (cube, ...)
+	
+public:	
+	// Sets default values for this actor's properties
+	AOSMElementActor(const FObjectInitializer& ObjectInitializer);
+
+	// Called every frame
+	virtual void Tick(float DeltaTime);
+
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+
+};

--- a/OSMProject/Source/OSMProject/OSMProject.Build.cs
+++ b/OSMProject/Source/OSMProject/OSMProject.Build.cs
@@ -19,5 +19,19 @@ public class OSMProject : ModuleRules
 		// PrivateDependencyModuleNames.Add("OnlineSubsystem");
 
 		// To include OnlineSubsystemSteam, add it to the plugins section in your uproject file with the Enabled attribute set to true
+		bEnableUndefinedIdentifierWarnings = false; //error C4668 to warning, for osmium library.
+		
+		//EXTERN DEPENDANCIES
+		//OSMIUM
+		PublicIncludePaths.Add("D:/vcpkg/installed/x86-windows/include");
+		PublicIncludePaths.Add("D:/protozero-code/include");
+		PublicIncludePaths.Add("D:/UnrealProjects/OSMProject/Dependancies/libosmium-2.15.0/include");
+		
+		//OUR OSM SOURCE FILES
+		PublicIncludePaths.Add("D:/UnrealProjects/OSMProject/SourceOSM/osmium");
+		PublicIncludePaths.Add("D:/UnrealProjects/OSMProject/SourceOSM/readosm");
+		
+		//READOSM
+		PublicAdditionalLibraries.Add("D:/vcpkg/installed/x86-windows/lib/readosm.lib");
 	}
 }

--- a/OSMProject/Source/OSMProject/OSMProjectGameModeBase.cpp
+++ b/OSMProject/Source/OSMProject/OSMProjectGameModeBase.cpp
@@ -1,10 +1,51 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 
 #include "OSMProjectGameModeBase.h"
+#include "Engine/GameEngine.h"
 #include "ViewerHUD.h"
 #include "PlayerPawn.h"
+#include "OSMElementActor.h"
 
 AOSMProjectGameModeBase::AOSMProjectGameModeBase() {
 	HUDClass = AViewerHUD::StaticClass();
 	DefaultPawnClass = APlayerPawn::StaticClass();
+	World_ = GetWorld();
+	osmLibChoice_ = OSMIUM;
+}
+
+bool AOSMProjectGameModeBase::SpawnNode(FVector location) {
+	bool spawned = true;
+	if (World_)
+	{
+		const FRotator tempRotation = FRotator(0.);
+		AOSMElementActor* const OSMElement = World_->SpawnActor<AOSMElementActor>(AOSMElementActor::StaticClass(), location, tempRotation);
+		if (OSMElement != NULL) GEngine->AddOnScreenDebugMessage(-1, 10.0f, FColor::Red, TEXT("OSMElement spawned."));
+	}
+	else {
+		spawned = false;
+	}
+	return spawned;
+}
+
+/*void AOSMProjectGameModeBase::testReadosm() {
+	OsmWithreadosm o;
+	std::vector<std::string> filtre;
+	filtre.push_back("");
+	filtre.push_back("");
+	std::vector<Nodereadosm> Ns;
+	std::vector<Wayreadosm> Ws;
+	std::vector<Relationreadosm> Rs;
+	o.initWithCat(filtre, filtre, filtre);
+
+	Ns = o.getNodes();
+	Ws = o.getWays();
+	Rs = o.getRelations();
+}*/
+
+void AOSMProjectGameModeBase::PostLogin(APlayerController* NewPlayer)
+{
+	Super::PostLogin(NewPlayer);
+	//GEngine->AddOnScreenDebugMessage(-1, 10.0f, FColor::Red, TEXT("Logged."));
+	//testReadosm();
+	bool b = SpawnNode(FVector(1000.f, 100.f, 150.f));
 }

--- a/OSMProject/Source/OSMProject/OSMProjectGameModeBase.h
+++ b/OSMProject/Source/OSMProject/OSMProjectGameModeBase.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/GameModeBase.h"
+//#include "osmPart/osmPart/osmPart/OsmWithreadosm.h"
 #include "OSMProjectGameModeBase.generated.h"
 
 /**
@@ -14,5 +15,14 @@ class OSMPROJECT_API AOSMProjectGameModeBase : public AGameModeBase
 {
 	GENERATED_BODY()
 
+private:
+		UWorld* World_;
+		enum osm_library_choice {READOSM, OSMIUM};
+		osm_library_choice osmLibChoice_;
+
+public:
 		AOSMProjectGameModeBase();
+		virtual void PostLogin(APlayerController* NewPlayer);
+		bool SpawnNode(FVector location);
+		//void testReadosm();
 };

--- a/OSMProject/Source/OSMProject/PlayerPawn.cpp
+++ b/OSMProject/Source/OSMProject/PlayerPawn.cpp
@@ -95,6 +95,25 @@ void APlayerPawn::Tick(float DeltaTime)
 	}
 }
 
+void APlayerPawn::GameMenu() {
+	APlayerController* const PlayerController = Cast<APlayerController>(GEngine->GetFirstLocalPlayerController(GetWorld()));
+	bool inGameMenu = Hud->getGameMenuVisibility();
+	if (inGameMenu) {
+		//Exit game menu, then exit pause.
+		Hud->setCrosshairColor(FColor::White);
+		Hud->setInGameCrosshairVisibility(true);
+		Hud->setGameMenuVisibility(false);
+		if(PlayerController != NULL) PlayerController->SetPause(false);
+	}
+	else {
+		//Pause, then show game menu.
+		if(PlayerController != NULL) PlayerController->SetPause(true);
+		Hud->setInGameCrosshairVisibility(false);
+		Hud->setCrosshairColor(FColor::Black);
+		Hud->setGameMenuVisibility(true);
+	}
+}
+
 // Called to bind functionality to input
 void APlayerPawn::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 {
@@ -105,6 +124,9 @@ void APlayerPawn::SetupPlayerInputComponent(UInputComponent* PlayerInputComponen
 	PlayerInputComponent->BindAction("Raycast", IE_Pressed, this, &APlayerPawn::CastTrace);
 	PlayerInputComponent->BindAction("Hover Raycast", IE_Pressed, this, &APlayerPawn::CastHoverTrace);
 	PlayerInputComponent->BindAction("Hide/Show selected actor", IE_Pressed, this, &APlayerPawn::ChangeSelectedActorVisibility);
+
+	//This action will always trigger even if game is paused.
+	PlayerInputComponent->BindAction("Open Menu", IE_Pressed, this, &APlayerPawn::GameMenu).bExecuteWhenPaused = true;
 
 	PlayerInputComponent->BindAxis("MoveForward", this, &APlayerPawn::MoveForward);
 	PlayerInputComponent->BindAxis("MoveRight", this, &APlayerPawn::MoveRight);

--- a/OSMProject/Source/OSMProject/PlayerPawn.h
+++ b/OSMProject/Source/OSMProject/PlayerPawn.h
@@ -98,6 +98,12 @@ protected:
 	 * Request an unzoom on the user's camera.
 	 */
 	void ZoomOut();
+
+	//! GameMenu member.
+	/*!
+	* Open or close the game menu, based on inMenu boolean value.
+	*/
+	void GameMenu();
 	
 	//! CastTrace member.
 	/*! 

--- a/OSMProject/Source/OSMProject/ViewerHUD.cpp
+++ b/OSMProject/Source/OSMProject/ViewerHUD.cpp
@@ -4,42 +4,118 @@
 #include "Engine/Canvas.h"
 #include "Engine/GameEngine.h"
 #include "Public/CanvasItem.h"
+#include <fstream>
 
 AViewerHUD::AViewerHUD() {
 	CrosshairColor_ = FColor::White;
 	CrosshairSize_ = 15;
 	showInfoBox_ = false;
+	showCrosshair_ = true;
+	showGameMenu_ = false;
 	infoBoxLines_ = 1;
+	readOSMArborescenceFile();
 }
 
 void AViewerHUD::DrawHUD()
 {
 	Super::DrawHUD();
 
-	// Find the center of our canvas.
-	FVector2D Center(Canvas->ClipX * 0.5f, Canvas->ClipY * 0.5f);
-
-	// Crosshair
-	Draw2DLine(Center.X - CrosshairSize_, Center.Y, Center.X + CrosshairSize_, Center.Y, CrosshairColor_);
-	Draw2DLine(Center.X, Center.Y - CrosshairSize_, Center.X, Center.Y + CrosshairSize_, CrosshairColor_);
-
 	// Info Box
 	if (showInfoBox_) {
-		DrawRect(
-			FLinearColor(0, 0, 0, 0.4), // Box color and opacity.
-			Center.X + 150,				// X coordinates of box's top left corner.
-			40,							// Y coordinates of box's top left corner.
-			400,						// Box's width.
-			infoBoxLines_ * 15			// Box's height.
-		);
+		drawInfoBoxAndContent();
+	}
 
-		// Info Box content
-		for(int i = 0; i < infoBoxLines_; i++){
-			DrawText(TEXT("Here it'll be info box content !"), FLinearColor::White, Center.X + 150, 40 + (i * 15));
+	if (showGameMenu_) {
+		drawGameMenu();
+	}
+
+	// Crosshair
+	if (showCrosshair_) {
+		// Find the center of our canvas.
+		FVector2D Center(Canvas->ClipX * 0.5f, Canvas->ClipY * 0.5f);
+		drawCrosshair(Center.X, Center.Y);
+	}
+	else {
+		//Crosshair in Game Menu.
+		if (showGameMenu_) {
+			APlayerController* const PlayerController = Cast<APlayerController>(GEngine->GetFirstLocalPlayerController(GetWorld()));
+			if (PlayerController != NULL) {
+				PlayerController->GetMousePosition(MouseLocation_.X, MouseLocation_.Y);
+				drawCrosshair(MouseLocation_.X, MouseLocation_.Y);
+			}
 		}
 	}
 
-	DrawText(TEXT("ViewerHUD v1"), FLinearColor::Black, Center.X - 40, 10);
+	DrawText(TEXT("ViewerHUD v2"), FLinearColor::Black, (Canvas->ClipX * 0.5f) - 25, 10);
+}
+
+void AViewerHUD::drawCrosshair(int32 x, int32 y) {
+	int32 xmin = x - CrosshairSize_ < 0 ? 0 : x - CrosshairSize_;
+	int32 xmax = x + CrosshairSize_ > Canvas->ClipX ? Canvas->ClipX : x + CrosshairSize_;
+	int32 ymin = y - CrosshairSize_ < 0 ? 0 : y - CrosshairSize_;
+	int32 ymax = y + CrosshairSize_ > Canvas->ClipY ? Canvas->ClipY : y + CrosshairSize_;
+	Draw2DLine(xmin, y, xmax, y, CrosshairColor_);
+	Draw2DLine(x, ymin, x, ymax, CrosshairColor_);
+}
+
+void AViewerHUD::drawInfoBoxAndContent() {
+	DrawRect(
+		FLinearColor(0, 0, 0, 0.4),		// Box color and opacity.
+		(Canvas->ClipX * 0.5f) + 150,	// X coordinates of box's top left corner.
+		40,								// Y coordinates of box's top left corner.
+		400,							// Box's width.
+		infoBoxLines_ * 15				// Box's height.
+	);
+
+	// Info Box content
+	for (int i = 0; i < infoBoxLines_; i++) {
+		DrawText(TEXT("Here it'll be info box content !"), FLinearColor::White, (Canvas->ClipX * 0.5f) + 150, 40 + (i * 15));
+	}
+}
+
+void AViewerHUD::drawGameMenu() {
+	//Game Menu Window.
+	DrawRect(
+		FLinearColor(1, 0.863, 0.725, 1),
+		0,
+		0,
+		Canvas->ClipX,
+		Canvas->ClipY
+	);
+
+	//TO DO : Content
+
+	DrawText(TEXT("Press M to quit menu."), FLinearColor::Black, (Canvas->ClipX * 0.5f) - 40, Canvas->ClipY - 40);
+}
+
+void AViewerHUD::readOSMArborescenceFile() {
+	std::string filePath = "D:\\UnrealProjects\\OSMProject\\SourceOSM\\arbo.txt";
+	std::string line;
+
+	//int subcat = 0, tline = 0, cat = 0, emptyline = 0;
+
+	std::ifstream filestream(filePath, std::ios::in);
+
+	if (filestream)
+	{
+		while (getline(filestream, line)) {
+			if (line.find("\t\t") != std::string::npos) {
+				//subcat++;
+				if (line != "\t\t") { //not a blank line, subcat line.
+					//GEngine->AddOnScreenDebugMessage(-1, 10.0f, FColor::Red, FString(line.c_str()));
+				}
+			}
+			else {
+				if (line.find("\t") != std::string::npos) { //Which hashmap ? (way/node/relation)
+					//tline++;
+				}
+				else { //cat line.
+					//cat++;
+				}
+			}
+		}
+		//GEngine->AddOnScreenDebugMessage(-1, 30.0f, FColor::Red, TEXT("Subcats : ") + FString::FromInt(subcat) + TEXT(", Cats : ") + FString::FromInt(cat) + TEXT(", \\t lines : ") + FString::FromInt(tline) + TEXT(", empty lines : ") + FString::FromInt(emptyline));
+	}
 }
 
 void AViewerHUD::setCrosshairColor(FColor color) {
@@ -48,6 +124,18 @@ void AViewerHUD::setCrosshairColor(FColor color) {
 
 void AViewerHUD::setInfoBoxVisibility(bool v) {
 	showInfoBox_ = v;
+}
+
+void AViewerHUD::setInGameCrosshairVisibility(bool v) {
+	showCrosshair_ = v;
+}
+
+void AViewerHUD::setGameMenuVisibility(bool v) {
+	showGameMenu_ = v;
+}
+
+bool AViewerHUD::getGameMenuVisibility() {
+	return showGameMenu_;
 }
 
 void AViewerHUD::sendActorInfo(/* Parameter, by reference, in which it'll contain actor info */) {

--- a/OSMProject/Source/OSMProject/ViewerHUD.h
+++ b/OSMProject/Source/OSMProject/ViewerHUD.h
@@ -4,6 +4,8 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/HUD.h"
+#include <map>
+#include <string>
 #include "ViewerHUD.generated.h"
 
 /**
@@ -15,15 +17,30 @@ class OSMPROJECT_API AViewerHUD : public AHUD
 	GENERATED_BODY()
 	
 private:
+	FVector2D MouseLocation_;
 	FColor CrosshairColor_;
 	float CrosshairSize_;
 	int infoBoxLines_;
 	bool showInfoBox_;
+	bool showCrosshair_;
+	bool showGameMenu_;
+
+	std::map<std::string, std::pair<std::string, bool>> CatsSubcatsNodes_;
+	std::map<std::string, std::pair<std::string, bool>> CatsSubcatsWays_;
+	std::map<std::string, std::pair<std::string, bool>> CatsSubcatsRelations_;
+
+	void drawCrosshair(int32 x, int32 y);
+	void drawInfoBoxAndContent();
+	void drawGameMenu();
+	void readOSMArborescenceFile();
 
 public:
 	AViewerHUD();
 	virtual void DrawHUD() override;
 	void setCrosshairColor(FColor color);
 	void setInfoBoxVisibility(bool v);
+	void setInGameCrosshairVisibility(bool v);
+	void setGameMenuVisibility(bool v);
+	bool getGameMenuVisibility();
 	void sendActorInfo();
 };


### PR DESCRIPTION
- Création de la classe AOSMElementActor : pour l'instant, représente uniquement un node, sous la forme d'une sphère, interactive avec l'utilisateur (ce dernier peut le sélectionner et le cacher/afficher à sa guise)

- Ajout d'une méthode spawnNode, permettant d'afficher la sphère représentant une node à l'emplacement dans l'espace spécifié en paramètre.

- Ajout d'un menu en jeu : en appuyant sur la touche M (Echap est déjà pris par l'éditeur, pour quitter le mode jeu), le jeu se met en pause et la fenêtre représentant le menu, pour l'instant vierge, s'affiche : l'utilisateur peut déplacer un curseur par le biais de la souris sur le menu. Si l'utilisateur appuie de nouveau sur la touche M alors qu'il est dans le menu, ce dernier se ferme et le jeu n'est plus en pause.

- Ajouts de méthodes dans la classe AViewerHUD pour le dessin d'éléments d'HUD (Crosshair, Info Box, Ingame menu), l’accès à des variables de la classe (booléens d'affichage) et la lecture du fichier d'arborescence OSM pour le remplissage du menu en jeu, pour l'instant incomplet.

Note : Contient les ajouts de code relatifs à la tentative de fusion de nos parties OSM et Unreal, pour l'instant infructueuses (erreurs LNK2019 lorsqu'on tente de compiler par le biais d'Unreal des classes standard C++)