### PR TITLE
[25-03] Menu en jeu, seconde partie

### DIFF
--- a/OSMProject/Source/OSMProject/OSMProject.Build.cs
+++ b/OSMProject/Source/OSMProject/OSMProject.Build.cs
@@ -13,7 +13,7 @@ public class OSMProject : ModuleRules
 		PrivateDependencyModuleNames.AddRange(new string[] {  });
 
 		// Uncomment if you are using Slate UI
-		// PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });
+		PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });
 		
 		// Uncomment if you are using online features
 		// PrivateDependencyModuleNames.Add("OnlineSubsystem");

--- a/OSMProject/Source/OSMProject/SSGameMenuWidget.cpp
+++ b/OSMProject/Source/OSMProject/SSGameMenuWidget.cpp
@@ -1,0 +1,122 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "SSGameMenuWidget.h"
+#include "Engine/GameEngine.h"
+#include "SlateOptMacros.h"
+#include "SScrollBox.h"
+#include "SGridPanel.h"
+#include "STextBlock.h"
+#include "SCheckBox.h"
+#include "ViewerHUD.h"
+
+BEGIN_SLATE_FUNCTION_BUILD_OPTIMIZATION
+
+#define LOCTEXT_NAMESPACE "SSGameMenuWidget"
+
+void SSGameMenuWidget::Construct(const FArguments& InArgs)
+{
+	OwnerHUD = InArgs._OwnerHUDArg;
+	/*AViewerHUD* hud = OwnerHUD.Get();
+	auto map = hud->getCatsSubcatsNodes();*/
+
+	ChildSlot
+	[
+		SNew(SBorder)
+		[
+			SNew(SScrollBox)
+
+			+ SScrollBox::Slot()
+			.Padding(5.0f)
+			[
+				SNew(SGridPanel)
+					.FillColumn(0, 0.33f)
+					.FillColumn(1, 0.33f)
+					.FillColumn(2, 0.33f)
+
+				+ SGridPanel::Slot(0, 0)
+				[
+					SNew(STextBlock)
+						.Font(FSlateFontInfo(FPaths::EngineContentDir() / TEXT("Slate/Fonts/Verdana.ttf"), 18))
+						.Text(LOCTEXT("SFirstColumnLabel", "NODES"))
+				]
+
+				+ SGridPanel::Slot(1, 0)
+				[
+					SNew(STextBlock)
+						.Font(FSlateFontInfo(FPaths::EngineContentDir() / TEXT("Slate/Fonts/Verdana.ttf"), 18))
+						.Text(LOCTEXT("SSecondColumnLabel", "WAYS"))
+				]
+
+				+ SGridPanel::Slot(2, 0)
+				[
+					SNew(STextBlock)
+						.Font(FSlateFontInfo(FPaths::EngineContentDir() / TEXT("Slate/Fonts/Verdana.ttf"), 18))
+						.Text(LOCTEXT("SThirdColumnLabel", "RELATIONS"))
+				]
+
+				+ SGridPanel::Slot(0, 1)
+				[
+					SNew(STextBlock)
+						.Font(FSlateFontInfo(FPaths::EngineContentDir() / TEXT("Slate/Fonts/Verdana.ttf"), 18))
+						.Text(LOCTEXT("SCheckBoxLabel", "SCheckBox"))
+				]
+
+				+ SGridPanel::Slot(0, 2)
+					.HAlign(HAlign_Center)
+				[
+					SNew(SVerticalBox)
+
+					+ SVerticalBox::Slot()
+						.AutoHeight()
+					[
+						CreateCheckBox(LOCTEXT("SCheckBoxItemLabel01", "Option 1"))
+					]
+
+					+ SVerticalBox::Slot()
+						.AutoHeight()
+					[
+						CreateCheckBox(LOCTEXT("SCheckBoxItemLabel02", "Option 2"))
+					]
+
+					+ SVerticalBox::Slot()
+						.AutoHeight()
+					[
+						CreateCheckBox(LOCTEXT("SCheckBoxItemLabel03", "Option 3"))
+					]
+				]
+			]
+		]
+	];
+}
+
+TSharedRef<SWidget> SSGameMenuWidget::CreateCheckBox(const FText& CheckBoxText)
+{
+	return SNew(SCheckBox)
+		.ClickMethod(EButtonClickMethod::DownAndUp)
+		//.IsChecked(this, &SSGameMenuWidget::HandleCheckBoxChecked)
+		.OnCheckStateChanged(this, &SSGameMenuWidget::HandleCheckBoxCheckedStateChanged)
+		[
+			SNew(STextBlock)
+			.Font(FSlateFontInfo(FPaths::EngineContentDir() / TEXT("Slate/Fonts/Verdana.ttf"), 18))
+			.Text(CheckBoxText)
+		];
+}
+
+ECheckBoxState SSGameMenuWidget::HandleCheckBoxChecked() const
+{
+	return ECheckBoxState::Checked;
+}
+
+void SSGameMenuWidget::HandleCheckBoxCheckedStateChanged(ECheckBoxState NewState)
+{
+	if (NewState == ECheckBoxState::Checked) {
+		GEngine->AddOnScreenDebugMessage(-1, 10.0f, FColor::Red, TEXT("Checked."));
+	}
+	else { //Unchecked
+		GEngine->AddOnScreenDebugMessage(-1, 10.0f, FColor::Red, TEXT("Unchecked."));
+	}
+}
+
+#undef LOCTEXT_NAMESPACE
+
+END_SLATE_FUNCTION_BUILD_OPTIMIZATION

--- a/OSMProject/Source/OSMProject/SSGameMenuWidget.h
+++ b/OSMProject/Source/OSMProject/SSGameMenuWidget.h
@@ -1,0 +1,28 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+
+/**
+ * 
+ */
+class OSMPROJECT_API SSGameMenuWidget : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SSGameMenuWidget)
+	{}
+
+	SLATE_ARGUMENT(TWeakObjectPtr<class AViewerHUD>, OwnerHUDArg);
+
+	SLATE_END_ARGS()
+
+	/** Constructs this widget with InArgs */
+	void Construct(const FArguments& InArgs);
+private:
+	TWeakObjectPtr<class AViewerHUD> OwnerHUD;
+	TSharedRef<SWidget> CreateCheckBox(const FText& CheckBoxText);
+	ECheckBoxState HandleCheckBoxChecked() const;
+	void HandleCheckBoxCheckedStateChanged(ECheckBoxState NewState);
+};

--- a/OSMProject/Source/OSMProject/ViewerHUD.h
+++ b/OSMProject/Source/OSMProject/ViewerHUD.h
@@ -4,8 +4,10 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/HUD.h"
+#include "SSGameMenuWidget.h"
 #include <map>
 #include <string>
+#include <vector>
 #include "ViewerHUD.generated.h"
 
 /**
@@ -25,16 +27,20 @@ private:
 	bool showCrosshair_;
 	bool showGameMenu_;
 
-	std::map<std::string, std::pair<std::string, bool>> CatsSubcatsNodes_;
-	std::map<std::string, std::pair<std::string, bool>> CatsSubcatsWays_;
-	std::map<std::string, std::pair<std::string, bool>> CatsSubcatsRelations_;
+	enum DrawStatus { NOT_DRAWED, TO_BE_UNDRAWED, TO_BE_DRAWED, DRAWED };
+	std::map<std::string, std::vector<std::pair<std::string, DrawStatus>>> CatsSubcatsNodes_;
+	std::map<std::string, std::vector<std::pair<std::string, DrawStatus>>> CatsSubcatsWays_;
+	std::map<std::string, std::vector<std::pair<std::string, DrawStatus>>> CatsSubcatsRelations_;
 
 	void drawCrosshair(int32 x, int32 y);
 	void drawInfoBoxAndContent();
 	void drawGameMenu();
+	void addCatSubcatToHashmap(std::string category, std::string subcategory, std::map<std::string, std::vector<std::pair<std::string, DrawStatus>>>& hashmap);
 	void readOSMArborescenceFile();
 
 public:
+	TSharedPtr<SSGameMenuWidget> GMWidget;
+
 	AViewerHUD();
 	virtual void DrawHUD() override;
 	void setCrosshairColor(FColor color);
@@ -42,5 +48,9 @@ public:
 	void setInGameCrosshairVisibility(bool v);
 	void setGameMenuVisibility(bool v);
 	bool getGameMenuVisibility();
+	std::map<std::string, std::vector<std::pair<std::string, DrawStatus>>> getCatsSubcatsNodes();
+	std::map<std::string, std::vector<std::pair<std::string, DrawStatus>>> getCatsSubcatsWays();
+	std::map<std::string, std::vector<std::pair<std::string, DrawStatus>>> getCatsSubcatsRelations();
 	void sendActorInfo();
+	void BeginPlay();
 };

--- a/arbo.txt
+++ b/arbo.txt
@@ -59,7 +59,7 @@ amenity [Node / Way]
 		fast_food
 		food_court
 		ice_cream
-	 	pub
+		pub
 		restaurant
 		college
 		kindergarten
@@ -169,11 +169,11 @@ amenity [Node / Way]
 		fast_food
 		food_court
 		ice_cream
-	 	pub
+		pub
 		restaurant
 		college
 		kindergarten
-	 	library
+		library
 		archive
 		public_bookcase
 		school
@@ -1012,7 +1012,7 @@ natural [Node / Way]
 		fell
 		bare_rock
 		scree
-	 	shingle
+		shingle
 		sand
 		mud
 		water
@@ -1581,7 +1581,7 @@ shop [Node / Way]
 		dry_cleaning
 		e-cigarette
 		funeral_directors
-	 	laundry
+		laundry
 		money_lender
 		party
 		pawnbroker
@@ -1726,7 +1726,7 @@ sport [Node / Way]
 		golf
 		gymnastics
 		handball
-	 	hapkido
+		hapkido
 		horseshoes
 		horse_racing
 		ice_hockey


### PR DESCRIPTION
- Création d'un widget Slate, SSGameMenuWidget, qui permettra à l'utilisateur de sélectionner les éléments OSM qu'il souhaite afficher : pour l'instant, le menu n'est qu'à ses prémices (phase de tests) et n'est pas interactive pour le moment.

- La méthode readOSMArborescenceFile (classe AViewerHUD) lit désormais le fichier arbo.txt et remplit les dictionnaires en conséquence de ce qu'il lit avec les valeurs d'initialisation (clé catégorie, valeur paire <sous-catégorie, DrawStatus = NOT_DRAWED>)

- Mise à jour du fichier arbo.txt, pour supprimer des espaces en trop faussant les valeurs lues par nos programmes.